### PR TITLE
fix: Add an exclusion for WildFly

### DIFF
--- a/throw-if-servlet3/src/main/java/com/vaadin/servletdetector/ThrowIfServlet3.java
+++ b/throw-if-servlet3/src/main/java/com/vaadin/servletdetector/ThrowIfServlet3.java
@@ -1,5 +1,7 @@
 package com.vaadin.servletdetector;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import javax.servlet.ServletContainerInitializer;
@@ -8,9 +10,15 @@ import javax.servlet.ServletException;
 
 public class ThrowIfServlet3 implements ServletContainerInitializer {
 
+    private static final List<String> SERVLET_3_SUPPORTED_SERVERS_EXCLUSIONS =
+            Collections.singletonList("WildFly");
+
     public void onStartup(Set<Class<?>> c, ServletContext servletContext) throws ServletException {
-        throw new ServletException("This application requires Servlet 5+ and the server you are running on ("
-                + servletContext.getServerInfo() + ") supports Servlet 3");
+        String serverInfo = servletContext.getServerInfo();
+        if (SERVLET_3_SUPPORTED_SERVERS_EXCLUSIONS.stream().noneMatch(serverInfo::contains)) {
+            throw new ServletException("This application requires Servlet 5+ and the server you are running on ("
+                                       + serverInfo + ") supports Servlet 3");
+        }
     }
 
 }


### PR DESCRIPTION
Excludes WildFly from servlet version checking, since it triggers this listener even in latest Jakarta EE 9+ versions.