### PR TITLE
Define an automatic module name

### DIFF
--- a/throw-if-servlet3/pom.xml
+++ b/throw-if-servlet3/pom.xml
@@ -18,5 +18,19 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>throwifservlet3</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/throw-if-servlet5/pom.xml
+++ b/throw-if-servlet5/pom.xml
@@ -18,5 +18,20 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>throwifservlet5</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
Fixes problems using the jar as a module (Invalid module name: 'throw' is not a Java identifier) as reported by 'java -p throw-if-servlet3-1.0.1.jar'
